### PR TITLE
Initial ideas on how to make this a little more robust

### DIFF
--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import json
-import six
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.models import model_to_dict
-from django.utils.encoding import force_text
-from django.utils.functional import Promise
 
 from pusher import Pusher
 

--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -12,7 +12,6 @@ from pusher import Pusher
 
 class PusherMixin(object):
     pusher_include_model_fields = None
-    pusher_event_name = None
     pusher_exclude_model_fields = None
 
     def _object_to_json_serializable(self, object):

--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -34,39 +34,14 @@ class PusherMixin(object):
             key=getattr(settings, 'PUSHER_KEY'),
             secret=getattr(settings, 'PUSHER_SECRET'))
 
-    def _set_pusher_channel(self):
-        """ Set the pusher channel """
+    def set_pusher_channel(self):
+        """
+        Set the pusher channel
+        <model_name>_<primary_key>
+        """
         self.channel = '{model}_{pk}'.format(
             model=self.object._meta.model_name,
             pk=self.object.pk)
-
-    def _object_to_json_serializable(self, object):
-        model_dict = model_to_dict(
-            object, fields=self.pusher_include_model_fields,
-            exclude=self.pusher_exclude_model_fields)
-        json_data = json.dumps(model_dict, cls=DjangoJSONEncoder)
-        data = json.loads(json_data)
-
-        return data
-
-    def get_pusher_event_name(self):
-        """
-        Check pusher_event_name is set and is a string.
-        Override this method to dynamically set the pusher_event_name.
-        """
-        if self.pusher_event_name is None:
-            raise ImproperlyConfigured(
-                '{0}.pusher_event_name is not set. Define '
-                '{0}.pusher_event_name, or override '
-                '{0}.get_pusher_event_name().'.format(self.__class__.__name__))
-
-        if not isinstance(self.pusher_event_name,
-                          (six.string_types, six.text_type, Promise)):
-            raise ImproperlyConfigured(
-                '{0}.pusher_event_name must be a str or unicode '
-                'object.'.format(self.__class__.__name__))
-
-        return force_text(self.pusher_event_name)
 
     def get_pusher_payload(self, data):
         """

--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -72,12 +72,12 @@ class PusherMixin(object):
             'user': username
         }
 
-    def send_pusher_notification(self, data):
-        """ Sends the notification to pusher """
+    def send_pusher_notification(self, event):
+        self.set_pusher()
+        self.set_pusher_channel()
+        data = self._object_to_json_serializable(self.object)
         self.pusher.trigger(
-            [self.channel],
-            self.get_pusher_event_name(),
-            self.get_pusher_payload(data))
+            [self.channel], event, self.get_pusher_payload(data))
 
 
 class PusherUpdateMixin(PusherMixin):

--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -1,54 +1,147 @@
 # -*- coding: utf-8 -*-
 
 import json
+import six
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.forms.models import model_to_dict
+from django.utils.encoding import force_text
+from django.utils.functional import Promise
 
 from pusher import Pusher
 
 
 class PusherMixin(object):
     pusher_include_model_fields = None
+    pusher_event_name = None
     pusher_exclude_model_fields = None
-    
-    def render_to_response(self, context, **response_kwargs):
 
-        channel = u"{model}_{pk}".format(
+    def _set_pusher(self):
+        """
+        Check that pusher settings exist or raise ValidationError.
+        Create Pusher on object.
+        """
+        app_id = getattr(settings, 'PUSHER_APP_ID', None)
+        key = getattr(settings, 'PUSHER_KEY', None)
+        secret = getattr(settings, 'PUSHER_SECRET', None)
+
+        if not all([app_id, key, secret]):
+            raise ImproperlyConfigured(
+                'Pusher settings are not defined. Make sure PUSHER_APP_ID, '
+                'PUSHER_KEY and PUSHER_SECRET are set in your settings file.')
+
+        self.pusher = Pusher(
+            app_id=getattr(settings, 'PUSHER_APP_ID'),
+            key=getattr(settings, 'PUSHER_KEY'),
+            secret=getattr(settings, 'PUSHER_SECRET'))
+
+    def _set_pusher_channel(self):
+        """ Set the pusher channel """
+        self.channel = '{model}_{pk}'.format(
             model=self.object._meta.model_name,
-            pk=self.object.pk
-        )
-        
-        data = self.__object_to_json_serializable(self.object)
-        
-        pusher = Pusher(app_id=settings.PUSHER_APP_ID,
-                        key=settings.PUSHER_KEY,
-                        secret=settings.PUSHER_SECRET)
-        pusher.trigger(
-            [channel, ],
-            self.pusher_event_name,
-            {
-                'object': data,
-                'user': self.request.user.username
-            }
-        )
+            pk=self.object.pk)
 
-        return super(PusherMixin, self).render_to_response(context, **response_kwargs)
-        
-    def __object_to_json_serializable(self, object):
-        model_dict = model_to_dict(object, 
-                                   fields=self.pusher_include_model_fields, exclude=self.pusher_exclude_model_fields)
+    def _object_to_json_serializable(self, object):
+        model_dict = model_to_dict(
+            object, fields=self.pusher_include_model_fields,
+            exclude=self.pusher_exclude_model_fields)
         json_data = json.dumps(model_dict, cls=DjangoJSONEncoder)
         data = json.loads(json_data)
+
         return data
+
+    def get_pusher_event_name(self):
+        """
+        Check pusher_event_name is set and is a string.
+        Override this method to dynamically set the pusher_event_name.
+        """
+        if self.pusher_event_name is None:
+            raise ImproperlyConfigured(
+                '{0}.pusher_event_name is not set. Define '
+                '{0}.pusher_event_name, or override '
+                '{0}.get_pusher_event_name().'.format(self.__class__.__name__))
+
+        if not isinstance(self.pusher_event_name,
+                          (six.string_types, six.text_type, Promise)):
+            raise ImproperlyConfigured(
+                '{0}.pusher_event_name must be a str or unicode '
+                'object.'.format(self.__class__.__name__))
+
+        return force_text(self.pusher_event_name)
+
+    def get_pusher_payload(self, data):
+        """
+        Method responsible for building payload data for pusher.
+        Override this method to customize the data sent to pusher.
+        Method should return a dict.
+        """
+        user = self.request.user
+        username = user.username
+
+        if user.is_anonymous():
+            username = 'Anonymous User'
+
+        return {
+            'object': data,
+            'user': username
+        }
+
+    def send_pusher_notification(self, data):
+        """ Sends the notification to pusher """
+        self.pusher.trigger(
+            [self.channel],
+            self.get_pusher_event_name(),
+            self.get_pusher_payload(data))
 
 
 class PusherUpdateMixin(PusherMixin):
-    pusher_event_name = u"update"
+    pusher_event_name = 'update'
+
+    def form_valid(self, form):
+        """
+        Call super first to make sure the object saves.
+        Call pusher methods and send notification.
+        """
+        response = super(PusherUpdateMixin, self).form_valid(form)
+
+        self._set_pusher()
+        self._set_pusher_channel()
+        data = self._object_to_json_serializable(self.object)
+        self.send_pusher_notification(data)
+
+        return response
+
 
 class PusherDetailMixin(PusherMixin):
-    pusher_event_name = u"view"
-    
+    pusher_event_name = 'view'
+
+    def render_to_response(self, context, **kwargs):
+        """
+        Generate Response first.
+        Send pusher notification.
+        """
+        response = super(PusherDetailMixin, self).render_to_response(
+            context, **kwargs)
+
+        self._set_pusher()
+        self._set_pusher_channel()
+        data = self._object_to_json_serializable(self.object)
+        self.send_pusher_notification(data)
+
+        return response
+
+
 class PusherDeleteMixin(PusherMixin):
-    pusher_event_name = u"delete"
+    pusher_event_name = 'delete'
+
+    def delete(self, *args, **kwargs):
+        response = super(PusherDeleteMixin, self).delete(*args, **kwargs)
+
+        self._set_pusher()
+        self._set_pusher_channel()
+        data = self._object_to_json_serializable(self.object)
+        self.send_pusher_notification(data)
+
+        return response

--- a/pusherable/mixins.py
+++ b/pusherable/mixins.py
@@ -15,11 +15,23 @@ class PusherMixin(object):
     pusher_event_name = None
     pusher_exclude_model_fields = None
 
-    def _set_pusher(self):
+    def _object_to_json_serializable(self, object):
+        model_dict = model_to_dict(
+            object, fields=self.pusher_include_model_fields,
+            exclude=self.pusher_exclude_model_fields)
+        json_data = json.dumps(model_dict, cls=DjangoJSONEncoder)
+        data = json.loads(json_data)
+
+        return data
+
+    def set_pusher(self):
         """
         Check that pusher settings exist or raise ValidationError.
         Create Pusher on object.
         """
+        if hasattr(self, 'pusher') and isinstance(self.pusher, Pusher):
+            return
+
         app_id = getattr(settings, 'PUSHER_APP_ID', None)
         key = getattr(settings, 'PUSHER_KEY', None)
         secret = getattr(settings, 'PUSHER_SECRET', None)

--- a/pusherable/templatetags/pusherable_tags.py
+++ b/pusherable/templatetags/pusherable_tags.py
@@ -3,9 +3,10 @@ from django.conf import settings
 
 register = template.Library()
 
+
 @register.simple_tag
 def pusherable_script():
-    return "<script src=\"//js.pusher.com/2.2/pusher.min.js\" type=\"text/javascript\"></script>"
+    return "<script src=\"//js.pusher.com/3.0/pusher.min.js\" type=\"text/javascript\"></script>"
 
 
 @register.simple_tag

--- a/pusherable/templatetags/pusherable_tags.py
+++ b/pusherable/templatetags/pusherable_tags.py
@@ -6,7 +6,8 @@ register = template.Library()
 
 @register.simple_tag
 def pusherable_script():
-    return "<script src=\"//js.pusher.com/3.0/pusher.min.js\" type=\"text/javascript\"></script>"
+    return ('<script src="//js.pusher.com/3.0/pusher.min.js" '
+            'type="text/javascript"></script>')
 
 
 @register.simple_tag

--- a/pusherable/templatetags/pusherable_tags.py
+++ b/pusherable/templatetags/pusherable_tags.py
@@ -11,23 +11,22 @@ def pusherable_script():
 
 
 @register.simple_tag
-def pusherable_subscribe(event, instance):
-
-    channel = u"{model}_{pk}".format(
-        model=instance._meta.model_name,
-        pk=instance.pk
-    )
+def pusherable_subscribe(instance):
+    """
+    Channel: <model_name>_<model_primary_key>
+    """
+    channel = '{model_name}_{model_pk}'.format(
+        model_name=instance._meta.model_name, model_pk=instance.pk)
 
     return """
-    <script type=\"text/javascript\">
-    var pusher = new Pusher('{key}');
-    var channel = pusher.subscribe('{channel}');
-    channel.bind('{event}', function(data) {{
-      pusherable_notify('{event}', data);
-    }});
+    <script>
+        var pusher = new Pusher('{api_key}'),
+            channel = pusher.subscribe('{channel}');
+        channel.bind_all(function(event, data) {{
+            if (event.indexOf('pusher:') === 0) {{
+                return false;
+            }}
+            pusherable_notify(event, data);
+        }});
     </script>
-    """.format(
-        key=settings.PUSHER_KEY,
-        channel=channel,
-        event=event
-    )
+    """.format(api_key=settings.PUSHER_KEY, channel=channel)


### PR DESCRIPTION
![I'll allow it](http://www.reactiongifs.com/r/allw.gif)
## Initial ideas on how to make this a little more robust

I haven't included any tests nor is this complete. This is more for presenting a different direction for the mixins. I've pulled some ideas and code from my own project [django-braces](https://github.com/brack3t/django-braces).
- The `pusher_event_name` has it's own `get_pusher_event_name` method. This adds a couple of benefits.
  - You can check that the name was set and that is of type string or unicode. If not, you can raise a nice, easy to read error.
  - You can override the method and programmatically generate the name if you need to.
- `_set_pusher` method checks that the settings exist and gives a nice error message if settings are missing. You also have the option to override this method if for some reason you needed to switch accounts. Probably could take this further and check if `DEBUG=True` and have settings for a production account and a dev account. (probably remove the leading _ if it's meant to be overridden).
- `_set_pusher_channel` is pretty straight forward. Just setup the channel. Could override this as well to programmatically setup a channel based on some data, probably the instance (probably remove the leading _ if it's meant to be overridden).
- `get_pusher_payload` again is mainly there to be overridable. Gives you a simple place to step in, override and send whatever data makes sense to your application. I also added a quick check about the user being anonymous because I was getting back a blank username. Probably wouldn't make sense to have this in a production app, it's more for my sanity.
- `send_pusher_notification` is straight forward. Again, easily overridable.
- Added some PEP8 love.

I removed the `render_to_response` method from the mixin itself and moved that to the `PusherDetailMixin`.

`PusherUpdateMixin` overrides the `form_valid` method.

`PusherDeleteMixin` overrides the `delete` method.

This isn't complete by any means but it does work. If you like the direction I was headed with this, I can flesh it out some more and obviously add docs and tests.
